### PR TITLE
feat(messages): added created_at field to message 

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,11 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rocket = { version = "=0.5.0-rc.3", features = ["json"] }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
-sqlx = { version = "0.6.3", features = ["postgres", "runtime-tokio-rustls", "migrate", "uuid"]}
-rocket_db_pools = { version = "=0.1.0-rc.3", features = ["sqlx_postgres"]}
+common = { path = "../common" }
 dotenv = "0.15.0"
 
-common = { path = "../common" }
+rocket = { version = "=0.5.0-rc.3", features = ["json"] }
+rocket_db_pools = { version = "=0.1.0-rc.3", features = ["sqlx_postgres"]}
+
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+
+sqlx = { version = "0.6.3", features = ["postgres", "runtime-tokio-rustls", "migrate", "uuid", "chrono"]}
+chrono = { version = "0.4.26", features = ["serde"] }
+

--- a/backend/migrations/0002_message_created_at.down.sql
+++ b/backend/migrations/0002_message_created_at.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE message DROP COLUMN IF EXISTS created_at;

--- a/backend/migrations/0002_message_created_at.up.sql
+++ b/backend/migrations/0002_message_created_at.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TABLE message ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();

--- a/backend/src/messages.rs
+++ b/backend/src/messages.rs
@@ -19,20 +19,22 @@ struct CreateMessageSchema {
 struct MessageModel {
     id: i64,
     message: String,
+    created_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[get("/<id>")]
 async fn read_message(mut db: Connection<FlukeDb>, id: i64) -> Result<Json<MessageModel>> {
-    let message = sqlx::query_as!(MessageModel, "SELECT * FROM message WHERE id = $1", id)
-        .fetch_one(&mut *db)
-        .await?;
+    let message: MessageModel =
+        sqlx::query_as!(MessageModel, "SELECT * FROM message WHERE id = $1", id)
+            .fetch_one(&mut *db)
+            .await?;
 
     Ok(Json(message))
 }
 
 #[get("/")]
 async fn list_messages(mut db: Connection<FlukeDb>) -> Result<Json<Vec<MessageModel>>> {
-    let messages = sqlx::query_as!(MessageModel, "SELECT id, message FROM message")
+    let messages = sqlx::query_as!(MessageModel, "SELECT * FROM message")
         .fetch_all(&mut *db)
         .await?;
 


### PR DESCRIPTION
### Description of changes:
- Added the migration `0002`
  - Creates a timezone-aware `DateTime` field on the message table that is defaulted to `NOW()`
  - This will automatically get set when an object is created because of the `default`
- Added the `chrono` package as well as the `chrono` feature for `sqlx` for handling these date types
- Added the `created_at` field to the `MessageModel`

### Example object gotten via Fluke API:
```json
{
    "id": 1,
    "message": "Test message",
    "created_at": "2023-06-18T23:47:56.858068Z"
}