### PR TITLE
fix: add string for which field was queried leading to UserNotFound + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,5 @@ or run `dev/serve.sh`
 
 ### Stack
 - [yew.rs](https://yew.rs/)
-- [rocket.rs](https://rocket.rs/)  <-- Being phased out
 - [axum](https://github.com/tokio-rs/axum)
 - [sqlx.rs](https://docs.rs/sqlx/0.6.3/sqlx/index.html)

--- a/backend/src/controllers/user.rs
+++ b/backend/src/controllers/user.rs
@@ -39,7 +39,7 @@ pub async fn login_user(
     )
     .fetch_optional(&pool)
     .await
-    .map_err(|_| CustomError::UserNotFound)?;
+    .map_err(|_| CustomError::UserNotFound(params.email.to_string()))?;
     match result {
         Some(user_model) => {
             let response = UserLoginResponse {
@@ -48,7 +48,7 @@ pub async fn login_user(
             };
             Ok(Json(response))
         }
-        None => Err(CustomError::UserNotFound),
+        None => Err(CustomError::UserNotFound(params.email.to_string())),
     }
 }
 
@@ -59,7 +59,7 @@ pub async fn get_user(
     let user: UserModel = sqlx::query_as!(UserModel, "SELECT * FROM fluke_user WHERE id = $1", id)
         .fetch_one(&pool)
         .await
-        .map_err(|_| CustomError::UserNotFound)?;
+        .map_err(|_| CustomError::UserNotFound(id.to_string()))?;
 
     Ok(Json(user))
 }
@@ -124,7 +124,7 @@ pub async fn delete_user(
     sqlx::query_as!(UserModel, "SELECT * FROM fluke_user WHERE id = $1", id)
         .fetch_one(&pool)
         .await
-        .map_err(|_| CustomError::UserNotFound)?;
+        .map_err(|_| CustomError::UserNotFound(id.to_string()))?;
 
     let sql = "DELETE FROM fluke_user WHERE id = $1";
 
@@ -132,7 +132,7 @@ pub async fn delete_user(
         .bind(id)
         .execute(&pool)
         .await
-        .map_err(|_| CustomError::UserNotFound)?;
+        .map_err(|_| CustomError::UserNotFound(id.to_string()))?;
 
     Ok((StatusCode::OK, Json(json!({"message": "User deleted"}))))
 }

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -1,25 +1,28 @@
 use std::fmt;
 
-use axum::{http::StatusCode, Json, response::IntoResponse};
+use axum::{http::StatusCode, response::IntoResponse, Json};
 use serde_json::json;
-
 
 pub enum CustomError {
     BadRequest,
     MessageNotFound,
-    UserNotFound,
+    UserNotFound(String),
     InternalServerError,
 }
 
 impl IntoResponse for CustomError {
     fn into_response(self) -> axum::response::Response {
         let (status, error_message) = match self {
-            Self::InternalServerError => {
-                (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")
+            Self::InternalServerError => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Server Error".to_string(),
+            ),
+            Self::BadRequest => (StatusCode::BAD_REQUEST, "Bad Request".to_string()),
+            Self::MessageNotFound => (StatusCode::NOT_FOUND, "Message Not Found".to_string()),
+            Self::UserNotFound(user_param) => {
+                let msg = format!("User Not Found: {}", user_param);
+                (StatusCode::NOT_FOUND, msg)
             }
-            Self::BadRequest => (StatusCode::BAD_REQUEST, "Bad Request"),
-            Self::MessageNotFound => (StatusCode::NOT_FOUND, "Message Not Found"),
-            Self::UserNotFound => (StatusCode::NOT_FOUND, "User Not Found"),
         };
         (status, Json(json!({ "error": error_message }))).into_response()
     }


### PR DESCRIPTION
- During login, get user or delete user, a string is now displayed for which ID or email was "not found" in the custom UserNotFound error type. 

- Remove rocket.rs from stack in README