### PR TITLE
feat(message): added `updated_at` field to messages

### DIFF
--- a/backend/.sqlx/query-4bc77b6936bf96d58f3391d615ba910fedf7e4aa9d3150c7b3d6d24151a6dfab.json
+++ b/backend/.sqlx/query-4bc77b6936bf96d58f3391d615ba910fedf7e4aa9d3150c7b3d6d24151a6dfab.json
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "channel_id",
         "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
       }
     ],
     "parameters": {
@@ -37,6 +42,7 @@
       ]
     },
     "nullable": [
+      false,
       false,
       false,
       false,

--- a/backend/.sqlx/query-838e6d71cb92539416554ddaf9e6b4f6b2ce5b7a64e31878ba95cf95d34fb792.json
+++ b/backend/.sqlx/query-838e6d71cb92539416554ddaf9e6b4f6b2ce5b7a64e31878ba95cf95d34fb792.json
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "channel_id",
         "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
       }
     ],
     "parameters": {
@@ -35,6 +40,7 @@
       ]
     },
     "nullable": [
+      false,
       false,
       false,
       false,

--- a/backend/.sqlx/query-dbc2d6f1b64de27b816ca244bb5bd243945f8c8e0c4cb1ed7f4b0957e0f4097b.json
+++ b/backend/.sqlx/query-dbc2d6f1b64de27b816ca244bb5bd243945f8c8e0c4cb1ed7f4b0957e0f4097b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "UPDATE message SET message = $1 WHERE channel_id = $2 and id = $3 RETURNING *",
+  "query": "UPDATE message SET message = $1, updated_at = now() WHERE channel_id = $2 and id = $3 RETURNING *",
   "describe": {
     "columns": [
       {
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "channel_id",
         "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
       }
     ],
     "parameters": {
@@ -41,8 +46,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "76365a5fc70e9b1041190814dc2d84cffd36d230f0e8b95fdd8bd8e4629e9234"
+  "hash": "dbc2d6f1b64de27b816ca244bb5bd243945f8c8e0c4cb1ed7f4b0957e0f4097b"
 }

--- a/backend/.sqlx/query-fdf8c1579c7ee86db16d796da3571b9b79a2bc50f7b6c2447a848d5965228d9e.json
+++ b/backend/.sqlx/query-fdf8c1579c7ee86db16d796da3571b9b79a2bc50f7b6c2447a848d5965228d9e.json
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "channel_id",
         "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
       }
     ],
     "parameters": {
@@ -36,6 +41,7 @@
       ]
     },
     "nullable": [
+      false,
       false,
       false,
       false,

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "backend-axum"
+name = "backend"
 version = "0.1.0"
 edition = "2021"
 

--- a/backend/migrations/20230814233410_message_updated_at.down.sql
+++ b/backend/migrations/20230814233410_message_updated_at.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE message DROP COLUMN updated_at;

--- a/backend/migrations/20230814233410_message_updated_at.up.sql
+++ b/backend/migrations/20230814233410_message_updated_at.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TABLE message ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();

--- a/backend/src/db/messages.rs
+++ b/backend/src/db/messages.rs
@@ -55,7 +55,7 @@ impl Db {
     ) -> Result<MessageModel, sqlx::Error> {
         sqlx::query_as!(
             MessageModel,
-            "UPDATE message SET message = $1 WHERE channel_id = $2 and id = $3 RETURNING *",
+            "UPDATE message SET message = $1, updated_at = now() WHERE channel_id = $2 and id = $3 RETURNING *",
             &message,
             channel_id,
             message_id

--- a/backend/src/models/message.rs
+++ b/backend/src/models/message.rs
@@ -17,6 +17,7 @@ pub struct MessageModel {
     pub id: i64,
     pub message: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
     pub user_id: i64,
     pub channel_id: i64,
 }


### PR DESCRIPTION
### Description of changes
- Added `updated_at` field for message table (up and down migration)
- Updated `db::message::update_message` to put `now()` into the `updated_at` field
- Ran `cargo sqlx prepare`

### Testing Strategy:
- Results after running an update on a message
- Note: `updated_at` time was updated
```
fluke=# select * from message;
 id |    message    |          created_at           | user_id | channel_id |          updated_at
----+---------------+-------------------------------+---------+------------+-------------------------------
  3 | test messaage | 2023-08-14 18:47:21.342491-05 |       1 |          3 | 2023-08-14 18:47:21.342491-05
(1 row)

fluke=# select * from message;
 id |     message     |          created_at           | user_id | channel_id |          updated_at
----+-----------------+-------------------------------+---------+------------+-------------------------------
  3 | update messaage | 2023-08-14 18:47:21.342491-05 |       1 |          3 | 2023-08-14 18:48:06.567496-05
(1 row)
```